### PR TITLE
Code spell checker 및 merlin 과 feather 에 공통으로 사용되는 룰 추가

### DIFF
--- a/import.js
+++ b/import.js
@@ -13,6 +13,13 @@ module.exports = {
     },
   },
   rules: {
+    'import-name/all-imports-name': [
+      'error',
+      {
+        react: 'React',
+        clsx: 'cx',
+      },
+    ],
     // 유사한 항목을 그룹으로 묶어서 정렬합니다.
     'simple-import-sort/imports': [
       'error',

--- a/import.js
+++ b/import.js
@@ -13,6 +13,7 @@ module.exports = {
     },
   },
   rules: {
+    // react, clsx 라이브러리를 import 할 때 이름을 React, cx로 제한합니다.
     'import-name/all-imports-name': [
       'error',
       {

--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
 module.exports = {
   extends: [
-    './react.js',
-    './typescript.js',
-    './bestpractice.js',
-    './import.js',
-    './prettier.js'
+    "./react.js",
+    "./typescript.js",
+    "./bestpractice.js",
+    "./import.js",
+    "./prettier.js",
+    "./spellchecker.js",
   ],
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@koreacreditdata/eslint-config",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
@@ -18,6 +18,7 @@
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
+    "eslint-plugin-spellcheck": "^0.0.19",
     "prettier": "^2.2.1",
     "react": "^17.0.1",
     "typescript": "^4.2.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@koreacreditdata/eslint-config",
-  "version": "0.3.2",
+  "version": "0.3.1",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {

--- a/react.js
+++ b/react.js
@@ -10,13 +10,35 @@ module.exports = {
     },
   },
   rules: {
-    "react/require-default-props": "off",
-    "react/jsx-props-no-spreading": "off",
-    "react/button-has-type": "off",
+    // 적절하게 쓰면 가독성을 해치지 않음
+    'no-nested-ternary': 'off',
+    // 한글 컴포넌트 import를 위함
+    'react/jsx-pascal-case': 'off',
+    // 한글/영어 혼용된 컴포넌트/메서드명 사용을 위함
+    'camelcase': 'off',
+    // react import를 jsx/tsx에 무조건 넣도록 하는 룰. tsconfig.comiplierOptions.jsx 가 react-jsx일 때는 필요 없음
+    'react/react-in-jsx-scope': 'off',
+    // typescript라서 필요없음
+    'react/require-default-props': 'off',
+    // props spreading 허용
+    'react/jsx-props-no-spreading': 'off',
+    // 리액트 컴포넌트 파일을 만들 때 .jsx 나 .tsx 확장자를 사용함
     'react/jsx-filename-extension': ['error', {
       extensions: ['.jsx', '.tsx'],
     }],
-
+    // div에 키보드 이벤트 없이 onClick 자유롭게 넣을 수 있게 함
+    'jsx-a11y/click-events-have-key-events': 'off',
+    // label 태그는 control 관련 태그를 감싸고 있어야 함
+    'jsx-a11y/label-has-associated-control': [
+      'error',
+      {
+        labelComponents: [],
+        labelAttributes: [],
+        controlComponents: [],
+        assert: 'either',
+        depth: 25,
+      },
+    ],
     // import 문을 통일하고, React 내장 Hooks는 `React.useState()` 형태로 사용합니다.
     // Bad: `import React, { useState } from 'react';`
     // Bad: `import * as React from 'react';`

--- a/react.js
+++ b/react.js
@@ -10,6 +10,9 @@ module.exports = {
     },
   },
   rules: {
+    "react/require-default-props": "off",
+    "react/jsx-props-no-spreading": "off",
+    "react/button-has-type": "off",
     'react/jsx-filename-extension': ['error', {
       extensions: ['.jsx', '.tsx'],
     }],

--- a/spellchecker.js
+++ b/spellchecker.js
@@ -6,15 +6,6 @@ module.exports = {
       {
         comments: false,
         ignoreRequire: true,
-        skipWords: [
-          'bg',
-          'cx',
-          'formatter',
-          'idx',
-          'num',
-          'postfix',
-          'svg',
-        ],
       },
     ],
   },

--- a/spellchecker.js
+++ b/spellchecker.js
@@ -1,0 +1,13 @@
+module.exports = {
+  plugins: ["spellcheck"],
+  rules: {
+    "spellcheck/spell-checker": [
+      "warn",
+      {
+        comments: false,
+        ignoreRequire: true,
+        skipWords: [],
+      },
+    ],
+  },
+};

--- a/spellchecker.js
+++ b/spellchecker.js
@@ -6,7 +6,15 @@ module.exports = {
       {
         comments: false,
         ignoreRequire: true,
-        skipWords: [],
+        skipWords: [
+          'bg',
+          'cx',
+          'formatter',
+          'idx',
+          'num',
+          'postfix',
+          'svg',
+        ],
       },
     ],
   },

--- a/typescript.js
+++ b/typescript.js
@@ -14,14 +14,49 @@ module.exports = {
         'plugin:import/typescript',
       ],
       rules: {
+        // 값을 정의하기 전에 사용하지 않습니다.
         'no-use-before-define': 'off',
-        '@typescript-eslint/no-use-before-define': 'error',
+        // function definition은 hoisting되기 때문에 필요없음
+        '@typescript-eslint/no-use-before-define': ['error', {
+          functions: false,
+        }],
 
         // Type 만 사용하는 경우 import 문에 type을 명시적으로 붙여줍니다. (https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export)
         '@typescript-eslint/consistent-type-imports': 'error',
 
         // 함수의 return type은 명시적으로 적는 대신 타입 추론을 이용합니다. (tsconfig에서 compilerOptions.noImplicitAny 사용을 권장합니다.)
         '@typescript-eslint/explicit-module-boundary-types': 'off',
+        // Promise 는 async/await 또는 then/catch 로 처리되야 합니다. 단 void 연산자를 사용할 경우 무시됩니다.
+        '@typescript-eslint/no-floating-promises': [
+          'error',
+          {
+            ignoreVoid: true,
+          },
+        ],
+        // Enums를 사용하려면, no-shadow 대신 @typescript-eslint/no-shadow 사용
+        'no-shadow': 'off',
+        '@typescript-eslint/no-shadow': 'error',
+
+        // void 연산자를 사용하지 않습니다. 단, 변수 할당이 아닌 구문으로는 사용할 수 있습니다.
+        'no-void': ['error', {
+          allowAsStatement: true
+        }],
+        // json import 허용
+        'import/extensions': [
+          'error',
+          {
+            ignorePackages: true,
+            pattern: {
+              js: 'never',
+              jsx: 'never',
+              ts: 'never',
+              tsx: 'never',
+              json: 'always',
+            },
+          },
+        ],
+        // no-null-assertion(!) 을 사용하지 않습니다.
+        '@typescript-eslint/no-non-null-assertion': 'off',
       },
     },
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -626,6 +626,15 @@ eslint-plugin-simple-import-sort@^7.0.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz#a1dad262f46d2184a90095a60c66fef74727f0f8"
   integrity sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==
 
+eslint-plugin-spellcheck@^0.0.19:
+  version "0.0.19"
+  resolved "http://localhost:4873/eslint-plugin-spellcheck/-/eslint-plugin-spellcheck-0.0.19.tgz#73926b94208ae93ea5be00a8844dcdf1d8d2bf6f"
+  integrity sha512-Vau+oCLT3IGx+inJV5rkuKlIwgka9L2is1SkztviIHN3apNnT2OrZoGy9Jt3gbcjjkfkIFMFSZjB+ijHCimbNA==
+  dependencies:
+    globals "^13.0.0"
+    hunspell-spellchecker "^1.0.2"
+    lodash "^4.17.15"
+
 eslint-scope@^5.0.0, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -860,6 +869,13 @@ globals@^12.1.0:
   dependencies:
     type-fest "^0.8.1"
 
+globals@^13.0.0:
+  version "13.9.0"
+  resolved "http://localhost:4873/globals/-/globals-13.9.0.tgz#4bf2bf635b334a173fb1daf7c5e6b218ecdc06cb"
+  integrity sha512-74/FduwI/JaIrr1H8e71UbDE+5x7pIPs1C2rrwC52SszOo043CsWOZEMW7o2Y58xwm9b+0RBKDxY5n2sUpEFxA==
+  dependencies:
+    type-fest "^0.20.2"
+
 globby@^11.0.1:
   version "11.0.2"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.2.tgz#1af538b766a3b540ebfb58a32b2e2d5897321d83"
@@ -908,6 +924,11 @@ hosted-git-info@^2.1.4:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"
   integrity sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==
+
+hunspell-spellchecker@^1.0.2:
+  version "1.0.2"
+  resolved "http://localhost:4873/hunspell-spellchecker/-/hunspell-spellchecker-1.0.2.tgz#a10b0bd2fa00a65ab62a4c6b734ce496d318910e"
+  integrity sha1-oQsL0voAplq2Kkxrc0zkltMYkQ4=
 
 ignore@^4.0.6:
   version "4.0.6"
@@ -1679,6 +1700,11 @@ type-check@^0.4.0, type-check@~0.4.0:
   integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
   dependencies:
     prelude-ls "^1.2.1"
+
+type-fest@^0.20.2:
+  version "0.20.2"
+  resolved "http://localhost:4873/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
+  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
 type-fest@^0.8.1:
   version "0.8.1"


### PR DESCRIPTION
### 작업 내용
- eslint code spell checker 적용
- merlin 및 feather 공통 룰 추가 
- rule 에 comment 추가

### 논의 하고 싶은 내용
- `skipWords` 현재 빈 배열로 처리했는데, ~~이대로 두고 사용하는 곳에서 추가해서 사용하면 될까요? 아니면,~~ 공통으로 사용할만한 단어들 (bg, cx, idx, num 등..) 을 미리 추가해놓을까요?
   - 공통으로 사용할 만한 단어 추가했습니다. 더 추가할 내용있으면 코멘트 부탁드립니다.
 
-> 어차피 override될 것이므로 `skipWords`는 비워두되, override하지 않을 저장소를 감안하여 옵션은 추가해둡니다.